### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@
 # against bad commits.
 
 name: build
+permissions:
+  contents: read
 on: [ pull_request, push ]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/TheDGOfficial/DarkUtils/security/code-scanning/1](https://github.com/TheDGOfficial/DarkUtils/security/code-scanning/1)

To fix the problem, add a `permissions` block to restrict the GITHUB_TOKEN privileges for this workflow. The best way is to add `permissions: contents: read` at the top level (before `jobs:`), so all jobs inherit minimal permissions. If a specific job needs broader permissions, those can be explicitly set at the job level. In this case, since no step requires write access to repository contents or other resources, the minimal permissions block is sufficient. Edit `.github/workflows/build.yml` to insert `permissions: contents: read` after the `name:` and before `on:` for clarity and convention.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
